### PR TITLE
 Make `example-all.js` show each spinner long enough #4 

### DIFF
--- a/example-all.js
+++ b/example-all.js
@@ -21,7 +21,7 @@ var showNextSpinner = function () {
 	if (spinner in spinners) {
 		var s = cliSpinners[spinners[spinner]];
 		next = setInterval(showNextFrame, s.interval || 100);
-		setTimeout(showNextSpinner, (s.interval || 100) * s.frames.length);
+		setTimeout(showNextSpinner, Math.max((s.interval || 100) * s.frames.length, 1000));
 	}
 };
 

--- a/example-all.js
+++ b/example-all.js
@@ -6,8 +6,6 @@ var frame = 0;
 var spinner = 0;
 var next;
 
-
-
 var showNextFrame = function () {
 	var frames = cliSpinners[spinners[spinner]].frames;
 	logUpdate(frames[frame++ % frames.length] + ' ' + spinners[spinner]);
@@ -16,7 +14,7 @@ var showNextFrame = function () {
 var showNextSpinner = function () {
 	if (next) {
 		clearInterval(next);
-		spinner++
+		spinner++;
 	}
 	if (spinner in spinners) {
 		var s = cliSpinners[spinners[spinner]];
@@ -25,7 +23,5 @@ var showNextSpinner = function () {
 	}
 };
 
-
-
 console.log(spinners.length + ' spinners\n');
-showNextSpinner()
+showNextSpinner();

--- a/example-all.js
+++ b/example-all.js
@@ -2,20 +2,30 @@
 var logUpdate = require('log-update');
 var cliSpinners = require('./');
 var spinners = Object.keys(cliSpinners);
-var i = 0;
-var j = 0;
-var frames = [];
+var frame = 0;
+var spinner = 0;
+var next;
+
+
+
+var showNextFrame = function () {
+	var frames = cliSpinners[spinners[spinner]].frames;
+	logUpdate(frames[frame++ % frames.length] + ' ' + spinners[spinner]);
+};
+
+var showNextSpinner = function () {
+	if (next) {
+		clearInterval(next);
+		spinner++
+	}
+	if (spinner in spinners) {
+		var s = cliSpinners[spinners[spinner]];
+		next = setInterval(showNextFrame, s.interval || 100);
+		setTimeout(showNextSpinner, (s.interval || 100) * s.frames.length);
+	}
+};
+
+
 
 console.log(spinners.length + ' spinners\n');
-
-setInterval(function () {
-	if (++i === frames.length) {
-		j++;
-		i = 0;
-	}
-
-	frames = cliSpinners[spinners[j]].frames;
-	logUpdate(frames[i] + ' ' + spinners[j]);
-}, 100);
-
-// $ node example.js
+showNextSpinner()

--- a/example-all.js
+++ b/example-all.js
@@ -18,8 +18,8 @@ var showNextSpinner = function () {
 	}
 	if (spinner in spinners) {
 		var s = cliSpinners[spinners[spinner]];
-		next = setInterval(showNextFrame, s.interval || 100);
-		setTimeout(showNextSpinner, Math.max((s.interval || 100) * s.frames.length, 1000));
+		next = setInterval(showNextFrame, s.interval);
+		setTimeout(showNextSpinner, Math.max(s.interval * s.frames.length, 1000));
 	}
 };
 


### PR DESCRIPTION
`example-all.js` now shows each spinner for [`Math.max((spinner.interval || 100) * spinner.frames.length, 1000)`](https://github.com/derhuerst/cli-spinners/blob/cb5b700dff54fc64f066f9d94c4b90c86255cda9/example-all.js#L24).