### PR TITLE
Add py-spinners to the Related section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ Each spinner comes with a recommended `interval` and an array of `frames`.
 
 - [ora](https://github.com/sindresorhus/ora) - Elegant terminal spinner
 - [CLISpinner](https://github.com/kiliankoe/CLISpinner) - Terminal spinners for Swift
-- [py-spinners](https://github.com/ManrajGrover/py-spinners) - Python wrapper for `cli-spinners` library
+- [py-spinners](https://github.com/ManrajGrover/py-spinners) - Python port
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ Each spinner comes with a recommended `interval` and an array of `frames`.
 
 - [ora](https://github.com/sindresorhus/ora) - Elegant terminal spinner
 - [CLISpinner](https://github.com/kiliankoe/CLISpinner) - Terminal spinners for Swift
+- [py-spinners](https://github.com/ManrajGrover/py-spinners) - Python wrapper for `cli-spinners` library
 
 
 ## License


### PR DESCRIPTION
This PR adds `py-spinners` to `Related` section. Thanks for being the inspiration for this package. 😸