### PR TITLE
docs(readme): Add link to Go port

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,3 +51,4 @@ The `random` spinner will return a random spinner each time it's called.
 - [CLISpinner](https://github.com/kiliankoe/CLISpinner) - Terminal spinners for Swift
 - [py-spinners](https://github.com/ManrajGrover/py-spinners) - Python port
 - [spinners](https://github.com/FGRibreau/spinners) - Terminal spinners for Rust
+- [go-spinners](https://github.com/gabe565/go-spinners) - Go port


### PR DESCRIPTION
Hi!

I ported this repo to Go. My repo generates spinner objects based on `spinners.json`, and will be kept up to date using Renovate. This PR adds a link to [gabe565/go-spinners](https://github.com/gabe565/go-spinners).

Thank you!